### PR TITLE
Clear selected events; View them in report window

### DIFF
--- a/SeeShellsV3/SeeShellsV3/Repositories/ReportEventCollection/IReportEventCollection.cs
+++ b/SeeShellsV3/SeeShellsV3/Repositories/ReportEventCollection/IReportEventCollection.cs
@@ -33,6 +33,11 @@ namespace SeeShellsV3.Repositories
         bool Remove(IShellEvent shellEvent);
 
         /// <summary>
+        /// Removes all events from the collection.
+        /// </summary>
+        void Clear();
+
+        /// <summary>
         /// Checks to see if a given Shell Event is already in the collection.
         /// </summary>
         /// <param name="shellEvent">Event to check if it is in the collection.</param>

--- a/SeeShellsV3/SeeShellsV3/Repositories/ReportEventCollection/ReportEventCollection.cs
+++ b/SeeShellsV3/SeeShellsV3/Repositories/ReportEventCollection/ReportEventCollection.cs
@@ -55,6 +55,12 @@ namespace SeeShellsV3.Repositories
             }
         }
 
+        public void Clear()
+        {
+            SelectedEvents.Clear();
+            HasEvents = false;
+        }
+
         public bool Contains(IShellEvent shellEvent)
         {
             return SelectedEvents.Contains(shellEvent);

--- a/SeeShellsV3/SeeShellsV3/UI/ExportWindow/ExportWindow.xaml
+++ b/SeeShellsV3/SeeShellsV3/UI/ExportWindow/ExportWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:SeeShellsV3.UI"
+        d:DataContext="{d:DesignInstance Type=local:ExportWindowVM}"
 		mc:Ignorable="d"
         Height="600" Width="800">
     <Window.Resources>
@@ -19,13 +20,43 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <StackPanel Grid.Row="0" Margin="5,5,5,5" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
+
+                <Grid x:Name="SelectedEvents" Grid.Row="0" Margin="10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="35"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock FontWeight="Bold" Text="Currently Selected ShellEvents" Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="{Binding Theme}"/>
+                    <Border Grid.Column="0" Grid.Row="1" Width="7.5in" BorderThickness="1" BorderBrush="{DynamicResource MahApps.Brushes.Gray8}">
+                        <DataGrid Name="TimezoneTable"
+                                  ItemsSource="{Binding ReportEvents.SelectedEvents}"
+                                  AutoGenerateColumns="False"
+                                  CanUserAddRows="False" IsReadOnly="True"
+                                  SelectionMode="Single">
+                            <DataGrid.RowStyle>
+                                <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource MahApps.Styles.DataGridRow}"/>
+                            </DataGrid.RowStyle>
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Event Time" Binding="{Binding TimeStamp}"/>
+                                <DataGridTextColumn Header="Description" Binding="{Binding Description}"/>
+                                <DataGridTextColumn Header="Type" Binding="{Binding TypeName}"/>
+                                <DataGridTextColumn Header="User" Binding="{Binding User.Name}"/>
+                                <DataGridTextColumn Header="Location Name" Binding="{Binding Place.Name}"/>
+                                <DataGridTextColumn Header="Location Path" Binding="{Binding Place.PathName}"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Border>
+                </Grid>
+
+                <StackPanel Grid.Row="1" Margin="5,5,5,5" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
                     <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{Binding Theme}" Text="Insert Module: "/>
                     <ComboBox Margin="2,2,2,2" VerticalAlignment="Center" HorizontalAlignment="Center" x:Name="moduleSelector" SelectedIndex="0" ItemsSource="{Binding moduleSelector}" IsEditable="False"/>
                     <Button VerticalAlignment="Center" HorizontalAlignment="Center" x:Name="Add_Module" FontFamily="Segoe MDL2 Assets" Content="&#xE710;" Click="Add_Module_Click"/>
                 </StackPanel>
-                <ItemsControl Grid.Row="1" x:Name="Modules" DockPanel.Dock="Top" ItemsSource="{Binding moduleList}">
+
+                <ItemsControl Grid.Row="2" x:Name="Modules" DockPanel.Dock="Top" ItemsSource="{Binding moduleList}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Grid Margin="10,10,10,10" Width="7.5in" Height="Auto">
@@ -65,7 +96,8 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-                <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom">
+
+                <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom">
                     <Button Click="Export_Click">
                         <TextBlock Text="{Binding Status}"/>
                     </Button>

--- a/SeeShellsV3/SeeShellsV3/UI/ExportWindow/ExportWindow.xaml.cs
+++ b/SeeShellsV3/SeeShellsV3/UI/ExportWindow/ExportWindow.xaml.cs
@@ -96,7 +96,7 @@ namespace SeeShellsV3.UI
             }
 		}
 
-		public void LoadHandler(object sender, EventArgs args)
+        public void LoadHandler(object sender, EventArgs args)
 		{
 			Mouse.OverrideCursor = null;
 			SelectedEvents.Visibility = ViewModel.HasSelectedEvents() ? Visibility.Visible : Visibility.Collapsed;

--- a/SeeShellsV3/SeeShellsV3/UI/ExportWindow/ExportWindow.xaml.cs
+++ b/SeeShellsV3/SeeShellsV3/UI/ExportWindow/ExportWindow.xaml.cs
@@ -28,6 +28,7 @@ namespace SeeShellsV3.UI
         ObservableCollection<IPdfModule> moduleList { get; }
         ObservableCollection<string> moduleSelector { get; }
         public void Export_PDF();
+        public bool HasSelectedEvents();
 		void Remove(IPdfModule sender);
 		void MoveDown(IPdfModule pdfModule);
 		void MoveUp(IPdfModule pdfModule);
@@ -66,7 +67,7 @@ namespace SeeShellsV3.UI
 			//svg.DefaultExt = ".pdf";
 			//svg.FileName = "SeeShellsReport";
 			//if (svg.ShowDialog() == true)
-			ViewModel.Export_PDF();
+            ViewModel.Export_PDF();
 		}
 
 
@@ -98,6 +99,7 @@ namespace SeeShellsV3.UI
 		public void LoadHandler(object sender, EventArgs args)
 		{
 			Mouse.OverrideCursor = null;
+			SelectedEvents.Visibility = ViewModel.HasSelectedEvents() ? Visibility.Visible : Visibility.Collapsed;
         }
-	}
+    }
 }

--- a/SeeShellsV3/SeeShellsV3/UI/ExportWindow/ExportWindowVM.cs
+++ b/SeeShellsV3/SeeShellsV3/UI/ExportWindow/ExportWindowVM.cs
@@ -25,7 +25,10 @@ namespace SeeShellsV3.UI
 		[Dependency] 
 		public ISelected Selected { get; set; }
 
-		public ObservableCollection<IPdfModule> moduleList { get; set; }
+		[Dependency] 
+        public IReportEventCollection ReportEvents { get; set; }
+
+        public ObservableCollection<IPdfModule> moduleList { get; set; }
 
 		public ObservableCollection<string> moduleSelector { get; set; }
 
@@ -54,7 +57,7 @@ namespace SeeShellsV3.UI
 			moduleSelector = new ObservableCollection<string>(Export.moduleNames.Keys);
 			moduleSelector.Insert(0, "Select Module");
 
-			Status = "Print";
+            Status = "Print";
 		}
 
 		public async void Export_PDF()
@@ -64,14 +67,19 @@ namespace SeeShellsV3.UI
 			Status = "Done.";
 			await Task.Run(() => Thread.Sleep(5000));
 			Status = "Print";
-		}
+        }
 
 		public void Remove(IPdfModule pdfModule)
 		{
 			moduleList.Remove(pdfModule);
 		}
 
-		public void MoveDown(IPdfModule pdfModule)
+        public bool HasSelectedEvents()
+        {
+			return ReportEvents.HasEvents;
+        }
+
+        public void MoveDown(IPdfModule pdfModule)
 		{
 			int pos = moduleList.IndexOf(pdfModule);
 			if (pos < moduleList.Count - 1)

--- a/SeeShellsV3/SeeShellsV3/UI/MainWindow/MainWindow.xaml
+++ b/SeeShellsV3/SeeShellsV3/UI/MainWindow/MainWindow.xaml
@@ -24,6 +24,7 @@
                         <MenuItem Header="Export Selected" Click="Export_CSV_Click"></MenuItem>
                         <MenuItem Header="Export Filtered" Click="Export_CSV_Click"></MenuItem>
                     </MenuItem>
+                    <MenuItem Header="Clear Selected Events" Click="Clear_Selected_Click"/>
                 </MenuItem>
                 <MenuItem Header="Reset" Background="Transparent" Click="ResetMenuItem_Click"/>
             </Menu>

--- a/SeeShellsV3/SeeShellsV3/UI/MainWindow/MainWindow.xaml.cs
+++ b/SeeShellsV3/SeeShellsV3/UI/MainWindow/MainWindow.xaml.cs
@@ -25,7 +25,7 @@ namespace SeeShellsV3.UI
         bool ImportFromRegistry(string hiveLocation = null);
         void RestartApplication(bool runAsAdmin = false);
         void ExportToCSV(string filePath, string source);
-        void AddToReportCollection();
+        void ClearSelected();
         void ChangePalette(string palette);
         void ResetToUtc();
         void ResetToLocal();
@@ -104,9 +104,9 @@ namespace SeeShellsV3.UI
                 ViewModel.RestartApplication(isElevated);
         }
 
-        private void AddReport_Click(object sender, RoutedEventArgs e)
+        private void Clear_Selected_Click(object sender, RoutedEventArgs e)
         {
-            ViewModel.AddToReportCollection();
+            ViewModel.ClearSelected();
         }
 
         private void ToggleSwitch_Toggled(object sender, RoutedEventArgs e)

--- a/SeeShellsV3/SeeShellsV3/UI/MainWindow/MainWindowVM.cs
+++ b/SeeShellsV3/SeeShellsV3/UI/MainWindow/MainWindowVM.cs
@@ -135,11 +135,9 @@ namespace SeeShellsV3.UI
             writer.Close();
         }
 
-        // TODO: Handle errors
-        public void AddToReportCollection()
+        public void ClearSelected()
         {
-            IShellEvent shell = Selected.CurrentInspector as IShellEvent;
-            ReportEvents.Add(shell);
+            ReportEvents.Clear();
         }
 
         public void ChangePalette(string palette)


### PR DESCRIPTION
This PR adds a button to clear all selected events. It can be found in the same menu as "As report" and "As CSV". It also adds a table that shows all the events that are added to reports. This is seen in the export menu. It only shows up if you have any events selected.